### PR TITLE
Release v1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class LeylineBot extends Client {
         super(options);
 
         // Custom properties for our bot
-        this.CURRENT_VERSION    = '0.9.0';
+        this.CURRENT_VERSION    = process.env.npm_package_version;
         this.logger     = require('./classes/Logger');
         this.config     = require('./config')[process.env.NODE_ENV || 'development'];
         this.commands   = new Collection();
@@ -115,8 +115,8 @@ const init = async function () {
 
     bot.logger.log('Connecting...');
     bot.login(process.env.BOT_TOKEN).then(() => {
-        bot.logger.debug(`Bot succesfully initialized, running version ${process.env.NODE_ENV}-${bot.CURRENT_VERSION}`);
-        process.env.NODE_ENV !== 'development' &&   //send message in log channel when staging bot is online
+        bot.logger.debug(`Bot succesfully initialized. Environment: ${process.env.NODE_ENV}. Version: ${bot.CURRENT_VERSION}`);
+        process.env.NODE_ENV !== 'development' &&   //send message in log channel when staging/prod bot is online
             bot.logDiscord(`\`${process.env.NODE_ENV}\` environment online, running version ${bot.CURRENT_VERSION}`);
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leyline-discord",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Leyline Discord bot",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
:LeylineLogo: Discord bot release v1.0.0 :LeylineLogo:
:beginner: New Features
- Added the ping command; use this to test the bot's responsiveness and latency
- Added the help command; this will display the bot's available commands and will automatically update whenever a command is added or changed
- Added a new section to the Leyline Discord profile that appears just under the username. It has the text "Leyline Profile", and when you click on it, it will redirect you to the public Leyline profile of that specific user
- Discord account linking was announced with the last web release, and the Leyline bot will award anyone who links their accounts with the Alpha Tester role! If you didn't have the role prior to linking your accounts, you will receive a Discord DM upon doing so to confirm that the bot recognized your action. Going forward, this will be the only way to obtain the Alpha Tester role, so be sure to link your Leyline/Discord accounts before we're out of the alpha phase!