### PR TITLE
Fix: good acts bot reactions not being removed 

### DIFF
--- a/classes/GoodActsReactionCollector.js
+++ b/classes/GoodActsReactionCollector.js
@@ -98,7 +98,7 @@ class GoodActsReactionCollector extends ReactionCollectorBase {
 			}});
 
 			//store the post for xp purposes
-			await XPService.addPost({
+			await XPService.addGoodAct({
 				uid: msg.author.id,
 				post_id: msg.id,
 			});

--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ Message.prototype.awaitInteractionFromUser = function ({user, ...options}) {
  * @returns {Promise<Message>} Resolves to itself once the cache update is complete
  */
 Message.prototype.fetchReactions = async function () {
-    this.reactions.cache = (await this.fetch()).reactions.cache;
+    this.reactions.cache = (await this.fetch({force: true})).reactions.cache;
     return this;
 };
 


### PR DESCRIPTION
## Summary of Changes
- Related to issue #43 
- Forces API call for `Message.fetchReactions()`, rather than using cached msg
- Also updates `GoodActsReactionCollector` to reflect prior changes made to `XPService`

## Imagery
None

