### PR TITLE
Bot now removes self-added goodactsreactioncollector reactions

### DIFF
--- a/classes/GoodActsReactionCollector.js
+++ b/classes/GoodActsReactionCollector.js
@@ -148,8 +148,8 @@ class GoodActsReactionCollector extends ReactionCollectorBase {
 			// ---  Give LLP to the users that have already reacted   ---
 			// --- (this includes the mod that just approved the msg) ---
 			await msg.fetchReactions();
-			for (const old_reaction of [...msg.reactions.cache.values()]) {
-				for(const old_user of [...(await old_reaction.users.fetch()).values()]) {
+			for(const old_reaction of [...msg.reactions.cache.values()]) {
+				for(const old_user of [...old_reaction.users.cache.values()]) {
 					if(!(await this.hasUserPreviouslyReacted({reaction: old_reaction, user: old_user, checkMsgReactions: false}))) {
 						//store user's reaction right away, because we do the same in the approved collector
 						await this.storeUserReaction(old_user);

--- a/classes/ReactionCollectorBase.js
+++ b/classes/ReactionCollectorBase.js
@@ -336,7 +336,7 @@ class ReactionCollectorBase {
             if(user.bot) return true;
         
             //check the local custom cache first, because it's quicker than calling the API
-            bot.logger.debug(`Custom Reaction Cache (${msg.id}): ${msg._cache.reacted_users}`);	//debug added 1.1.0
+            //bot.logger.debug(`Custom Reaction Cache (${msg.id}): ${msg._cache.reacted_users}`);	//debug added 1.1.0
             if(msg._cache.reacted_users?.includes(user.id)) return true;
             
             //now check the Discord.js message reaction cache

--- a/index.js
+++ b/index.js
@@ -245,7 +245,9 @@ Message.prototype.awaitInteractionFromUser = function ({user, ...options}) {
  * @returns {Promise<Message>} Resolves to itself once the cache update is complete
  */
 Message.prototype.fetchReactions = async function () {
-    this.reactions.cache = (await this.fetch({force: true})).reactions.cache;
+    //deep fetch - fetch the msg, then each reaction, then each reaction's users
+    for (const reaction of (await this.fetch()).reactions.cache.values())
+        this.reactions.resolve(reaction).users.cache = await reaction.users.fetch();
     return this;
 };
 


### PR DESCRIPTION
## Summary of Changes
- Related to issue #43 
- change `Message#fetchReactions` to a deep fetch
- Commented out logging that was added previously since functionality has consistently been performing well
