### PR TITLE
Fix RangeError with level#parseProgress

### DIFF
--- a/commands/user/level.js
+++ b/commands/user/level.js
@@ -24,7 +24,8 @@ class level extends Command {
     parseProgress({cur, max} = {}) {
         if(!max) return `${'🟩'.repeat(9)}⭐ **(MAX)**`;
         const percent = Math.round((cur / max) * 100);
-        const progress = Math.floor(percent/10);
+        let progress = Math.floor(percent/10);
+        if(progress > 10) progress = 10;    // user will appear to have the maximum value
         return `${'🟩'.repeat(progress)}${'⬛'.repeat(10 - progress)} **${percent}%**`;
     }
 


### PR DESCRIPTION
## Summary of Changes
- Related to #54 
- Add numerical check to enforce a maximum `progress` value
