### PR TITLE
Fix: Good Acts profile stat displaying zero

### DIFF
--- a/classes/services/XPService.js
+++ b/classes/services/XPService.js
@@ -92,7 +92,7 @@ export class XPService {
 			.firestore()
 			.collection(this.COLLECTION_PATH)
 			.where('uid', '==', uid)
-            .where('type', '==', 'posts')
+            .where('type', '==', 'good_acts')
 			//.where('created', '>', snapshotTime)
 			.get()).size;
     }


### PR DESCRIPTION
## Summary of Changes
- Related to #60 
- Changed query filtering process to reflect the new name of `good_acts`
