### PR TITLE
ReactionCollectorBase: Mods cannot approve their own submissions

### DIFF
--- a/classes/collectors/ReactionCollectorBase.js
+++ b/classes/collectors/ReactionCollectorBase.js
@@ -77,14 +77,16 @@ export class ReactionCollectorBase {
 				//this takes the place of the reactioncollector filter
 				if(!(bot.checkMod(user.id) && this.MOD_EMOJIS.some(e => e.unicode === reaction.emoji.name)))
 					return;
-
-				//end this modReactionCollector
-				this.collector.stop();
+				
 				await msg.fetchReactions();
 				//submission was rejected
 				if(reaction.emoji.name === '❌') 
 					return this.rejectSubmission({user});
+				//a moderator cannot approve their own submission
+				if(user.id === msg.author.id) return;
 
+				//end this modReactionCollector
+				this.collector.stop();
 				this.approveSubmission({reaction, user});
 			});
 		return this;
@@ -132,6 +134,9 @@ export class ReactionCollectorBase {
 	 */
 	rejectSubmission({user}) {
 		const { bot, msg } = this;
+
+		//end the modReactionCollector
+		this.collector.stop();
 
 		//update cloud
 		/*await*/ Firebase.rejectCollector({user, collector: this});

--- a/index.js
+++ b/index.js
@@ -248,6 +248,7 @@ Message.prototype.awaitInteractionFromUser = function ({user, ...options}) {
  * @returns {Promise<Message>} Resolves to itself once the cache update is complete
  */
 Message.prototype.fetchReactions = async function () {
+    Object.assign(this, { ...this, ...await this.fetch() });
     //deep fetch - fetch the msg, then each reaction, then each reaction's users
     for (const reaction of (await this.fetch()).reactions.cache.values())
         await this.reactions.resolve(reaction).users.fetch();


### PR DESCRIPTION
## Summary of Changes
-Related to #83 
-Mods cannot not approve their own submission
-Mods can reject their own submission
-Hopefully improved `Message.prototype.fetchReactions()` a little bit