### PR TITLE
Log submission approvals privately

### DIFF
--- a/classes/LeylineBot.js
+++ b/classes/LeylineBot.js
@@ -128,6 +128,19 @@ export class LeylineBot extends Client {
         });
     }
 
+    /**
+     * Sends a discord message on the bot's behalf to a private log channel, specific for submissions
+     * @param {Object} args
+     * @param {EmbedBase} args.embed Singular embed object to be sent in message
+     * @returns {Promise<Message>} Promise which resolves to the sent message
+     */
+    async logSubmission({embed, ...options}) {
+        return (await this.channels.fetch(this.config.channels.submission_log)).send({
+            embeds: [embed],
+            ...options,
+        });
+    }
+
     sendDisabledDmMessage(user) {
         this.msgBotChannel({
             content: user.toString(),

--- a/classes/collectors/GoodActsReactionCollector.js
+++ b/classes/collectors/GoodActsReactionCollector.js
@@ -69,17 +69,35 @@ export class GoodActsReactionCollector extends ReactionCollectorBase {
 				}),
 			});
 
-			//log approval in bot log
-			bot.logDiscord({
-				embed: new EmbedBase(bot, {
+			//Privately log approval
+			this.logApproval({
+				user,
+				embed_data: {
 					fields: [
 						{
-							name: `${this.media_type[0].toUpperCase() + this.media_type.slice(1)} Approved`,
-							value: `${bot.formatUser(user)} approved the [${this.media_type}](${msg.url} 'click to view message') posted in <#${msg.channel.id}> by ${bot.formatUser(msg.author)}`
+							name: 'Channel',
+							value: `<#${msg.channel.id}>`,
+							inline: true,
 						},
+						{
+							name: 'Approved By',
+							value: bot.formatUser(user),
+							inline: true,
+						},
+						{ name: '\u200b', value: '\u200b', inline: true },
+						{
+							name: 'Category',
+							value: msg._activityType,
+							inline: true,
+						},
+						{
+							name: 'Author',
+							value: bot.formatUser(msg.author),
+							inline: true,
+						},
+						{ name: '\u200b', value: '\u200b', inline: true },
 					],
-					thumbnail: { url: this.media_type === 'photo' ? msg.attachments.first().url : this.media_placeholder },
-				}),
+				},
 			});
 
 			this.setupApprovedCollector();

--- a/classes/collectors/KindWordsReactionCollector.js
+++ b/classes/collectors/KindWordsReactionCollector.js
@@ -34,19 +34,9 @@ export class KindWordsReactionCollector extends ReactionCollectorBase {
 				msg: msg.id,
 			});
 
-			//log approval in bot log
-			bot.logDiscord({
-				embed: new EmbedBase(bot, {
-					fields: [
-						{
-							name: `${this.media_type[0].toUpperCase() + this.media_type.slice(1)} Approved`,
-							value: `${bot.formatUser(user)} approved the [${this.media_type}](${msg.url} 'click to view message') posted in <#${msg.channel.id}> by ${bot.formatUser(msg.author)}`
-						},
-					],
-				}),
-			});
-
-			this.setupApprovedCollector();
+			//Privately log approval
+			this.logApproval({user})
+				.setupApprovedCollector();
 
 			//ensure user is connected to LL
 			const is_author_connected = await Firebase.isUserConnectedToLeyline(msg.author.id);

--- a/classes/collectors/ReactionCollectorBase.js
+++ b/classes/collectors/ReactionCollectorBase.js
@@ -127,9 +127,87 @@ export class ReactionCollectorBase {
 	}
 
 	/**
+	 * Log an approval in a private log channel
+	 * @param {Object} args Destructured arguments
+	 * @param {User} args.user Discord.js `User` that approved the submission
+	 * @param {Object} [args.embed_data] Embed data to be sent in the approval message
+	 */
+	logApproval({user, embed_data} = {}) {
+		const { bot, msg } = this;
+
+		//log rejection using bot method
+		bot.logSubmission({
+			embed: new EmbedBase(bot, {
+				title: 'Submission Approved',
+				url: msg.url,
+				fields: [
+					{
+						name: 'Channel',
+						value: `<#${msg.channel.id}>`,
+						inline: true,
+					},
+					{
+						name: 'Approved By',
+						value: bot.formatUser(user),
+						inline: true,
+					},
+					{
+						name: 'Author',
+						value: bot.formatUser(msg.author),
+						inline: true,
+					},
+				],
+				thumbnail: { url: this.media_type === 'photo' ? msg.attachments.first().url : this.media_placeholder },
+				...embed_data,
+			}).Success(),
+		});
+
+		return this;
+	}
+
+	/**
+	 * Log a rejection in a private log channel
+	 * @param {Object} args Destructured arguments
+	 * @param {User} args.user Discord.js `User` that rejected the submission
+	 * @param {Object} [args.embed_data] Embed data to be sent in the rejection message
+	 */
+	logRejection({user, embed_data} = {}) {
+		const { bot, msg } = this;
+
+		//log rejection using bot method
+		bot.logSubmission({
+			embed: new EmbedBase(bot, {
+				title: 'Submission Rejected',
+				url: msg.url,
+				fields: [
+					{
+						name: 'Channel',
+						value: `<#${msg.channel.id}>`,
+						inline: true,
+					},
+					{
+						name: 'Rejected By',
+						value: bot.formatUser(user),
+						inline: true,
+					},
+					{
+						name: 'Author',
+						value: bot.formatUser(msg.author),
+						inline: true,
+					},
+				],
+				thumbnail: { url: this.media_type === 'photo' ? msg.attachments.first().url : this.media_placeholder },
+				...embed_data,
+			}).Error(),
+		});
+
+		return this;
+	}
+
+	/**
 	 * Soft-rejects a submission and logs actions appropriately
-	 * @param {Object} [args] Destructured arguments
-	 * @param {User} [args.user] Discord.js `User` that rejected the submission
+	 * @param {Object} args Destructured arguments
+	 * @param {User} args.user Discord.js `User` that rejected the submission
 	 */
 	rejectSubmission({user}) {
 		const { bot, msg } = this;
@@ -144,17 +222,7 @@ export class ReactionCollectorBase {
 		msg.reactions.cache.each(reaction => reaction.users.remove(bot.user));
 
 		//log rejection
-		bot.logDiscord({
-			embed: new EmbedBase(bot, {
-				fields: [
-					{
-						name: `Submission Rejected`,
-						value: `${bot.formatUser(user)} rejected the [${this.media_type}](${msg.url} 'click to view message') posted in <#${msg.channel.id}> by ${bot.formatUser(msg.author)}`
-					},
-				],
-				thumbnail: { url: this.media_type === 'photo' ? msg.attachments.first().url : this.media_placeholder },
-			}).Error(),
-		});
+		this.logRejection({user});
 
 		return this;
 	}

--- a/classes/components/EmbedBase.js
+++ b/classes/components/EmbedBase.js
@@ -50,7 +50,7 @@ export class EmbedBase extends MessageEmbed {
     }
 
     Success() {
-        this.color = 0x35de2f;
+        this.color = 0x31d64d;
         return this;
     }
 

--- a/commands/development/embedtest.js
+++ b/commands/development/embedtest.js
@@ -12,27 +12,27 @@ class embedtest extends Command {
     async run({intr, opts}) {
         const { bot } = this;
         let expires = false;
-        bot.intrReply({intr, embed: new EmbedBase(bot).ErrorDesc('I ran into an error!')});
-        //bot.intrReply({intr, embed: new EmbedBase(bot, {
-        //    title: 'Justice Served',
-        //    fields: [
-        //        {
-        //            name: 'Issued By',
-        //            value: bot.formatUser(intr.user),
-        //            inline: true,
-        //        },
-        //        {
-        //            name: 'Reason',
-        //            value: null ?? 'No reason given',
-        //            inline: true,
-        //        },
-        //        {
-        //            name: 'Expires',
-        //            value: !!expires ? bot.formatTimestamp(expires) : 'No expiration',
-        //            inline: true,
-        //        },
-        //    ],
-        //}).Sentence(), files: ['./images/avatar-default.png']});
+        bot.intrReply({intr, embed: new EmbedBase(bot, {
+            title: 'Justice Served',
+            fields: [
+                {
+                    name: 'Issued By',
+                    value: bot.formatUser(intr.user),
+                    inline: true,
+                },
+                {
+                    name: 'Reason',
+                    value: null ?? 'No reason given',
+                    inline: true,
+                },
+                {
+                    name: 'Expires',
+                    value: !!expires ? bot.formatTimestamp(expires) : 'No expiration',
+                    inline: true,
+                },
+            ],
+            color: 0x31d64d,
+        })});
     }
 }
 

--- a/config.js
+++ b/config.js
@@ -32,6 +32,7 @@ export default {
                 public_log: '810265135419490314',
                 reward_log: '872724760805654538',
                 mod_log: '896539306800328734', //private mod log
+                submission_log: '903056355311644732',   //private submission log
                 ama_vc: '794283967460147221',
                 polls: '790063418898907166',
             },
@@ -83,7 +84,8 @@ export default {
                 private_log: '858141871788392448',
                 public_log: '858141914841481246',
                 reward_log: '858141836513771550',
-                mod_log: '892268882285457439', //private mod log
+                mod_log: '892268882285457439',  //private mod log
+                submission_log: '903055896173764659',   //private submission log
                 ama_vc: '869993145499287604',
                 polls: '877229054456107069',
             },

--- a/events/discord/messageCreate/goodActs.js
+++ b/events/discord/messageCreate/goodActs.js
@@ -25,13 +25,31 @@ export default class extends DiscordEvent {
 
 	rejectSubmission(msg) {
 		const { bot } = this;
-		bot.logDiscord({embed: new EmbedBase(bot, {
-			fields:[{
-				name: `Submission Auto-Rejected`,
-				value: `The [submission](${msg.url} 'click to view message') posted in <#${msg.channel.id}> by ${bot.formatUser(msg.author)} was automatically rejected because it did not contain a description.`,
-			}],
-			thumbnail: { url: msg.attachments.first().url },
-		}).Error()});
+		bot.logSubmission({
+			embed: new EmbedBase(bot, {
+				title: 'Submission Auto-Rejected',
+				description: 'The submission did not contain a description',
+				url: msg.url,
+				fields: [
+					{
+						name: 'Channel',
+						value: `<#${msg.channel.id}>`,
+						inline: true,	
+					},
+					{
+						name: 'Rejected By',
+						value: bot.formatUser(bot.user),
+						inline: true,
+					},
+					{
+						name: 'Author',
+						value: bot.formatUser(msg.author),
+						inline: true,
+					},
+				],
+				thumbnail: { url: msg.attachments.first().url },
+			}).Error(),
+		});
 
 		bot.sendDM({
 			user: msg.author,


### PR DESCRIPTION
## Summary of Changes
- Related to #106 
- Submission approvals/rejections are no longer logged in #bot-log
- Instead they are logged in a special #submission-log channel currently exclusive to staff only
- Darken the Success embed green

## Imagery
![image](https://user-images.githubusercontent.com/35435704/139167548-a211a56d-7577-47c5-b824-a45c431b292d.png)

