### PR TITLE
Fix PoG ledger approver

### DIFF
--- a/classes/collectors/GoodActsReactionCollector.js
+++ b/classes/collectors/GoodActsReactionCollector.js
@@ -123,7 +123,7 @@ export class GoodActsReactionCollector extends ReactionCollectorBase {
 			//award GP to msg author
 			else await this.awardApprovalGP({
 				user: msg.author,
-				approver: user.tag,
+				approver: user,
 				pog: `Discord <a href="${msg.url}">\
 					${msg._activityType} ${this.media_type[0].toUpperCase() + this.media_type.slice(1)}</a> Approved`,
 			});

--- a/classes/collectors/GoodActsReactionCollector.js
+++ b/classes/collectors/GoodActsReactionCollector.js
@@ -123,6 +123,7 @@ export class GoodActsReactionCollector extends ReactionCollectorBase {
 			//award GP to msg author
 			else await this.awardApprovalGP({
 				user: msg.author,
+				approver: user.tag,
 				pog: `Discord <a href="${msg.url}">\
 					${msg._activityType} ${this.media_type[0].toUpperCase() + this.media_type.slice(1)}</a> Approved`,
 			});

--- a/classes/collectors/KindWordsReactionCollector.js
+++ b/classes/collectors/KindWordsReactionCollector.js
@@ -59,6 +59,7 @@ export class KindWordsReactionCollector extends ReactionCollectorBase {
 			//award GP to msg author
 			else await this.awardApprovalGP({
 				user: msg.author,
+				approver: user,
 				pog: `Discord <a href="${msg.url}">Kind Words</a> Shared`,
 			});
 

--- a/classes/collectors/ReactionCollectorBase.js
+++ b/classes/collectors/ReactionCollectorBase.js
@@ -301,7 +301,7 @@ export class ReactionCollectorBase {
 
 		await Firebase.awardPoints(await Firebase.getLeylineUID(user.id), this.APPROVAL_GP, {
 			category: pog,
-			comment: `User's Discord ${this.media_type} (${msg.id}) was approved by ${approver}`,
+			comment: `User's Discord ${this.media_type} (${msg.id}) was approved by ${approver.tag}`,
 		});
 
 		//send dm to author

--- a/classes/collectors/ReactionCollectorBase.js
+++ b/classes/collectors/ReactionCollectorBase.js
@@ -295,12 +295,12 @@ export class ReactionCollectorBase {
      * @param {User} args.user Discord user
      * @param {string} args.pog "Proof of good" - message to display in GP history
 	 */
-	async awardApprovalGP({user, pog}) {
+	async awardApprovalGP({user, approver, pog}) {
 		const { bot, msg } = this;
 
 		await Firebase.awardPoints(await Firebase.getLeylineUID(user.id), this.APPROVAL_GP, {
 			category: pog,
-			comment: `User's Discord ${this.media_type} (${msg.id}) was approved by ${user.tag}`,
+			comment: `User's Discord ${this.media_type} (${msg.id}) was approved by ${approver}`,
 		});
 
 		//send dm to author

--- a/classes/collectors/ReactionCollectorBase.js
+++ b/classes/collectors/ReactionCollectorBase.js
@@ -293,6 +293,7 @@ export class ReactionCollectorBase {
 	 * Assumes all checks have been previously applied. 
 	 * @param {Object} args Destructured arguments
      * @param {User} args.user Discord user
+     * @param {User} args.approver Discord mod that approved the photo
      * @param {string} args.pog "Proof of good" - message to display in GP history
 	 */
 	async awardApprovalGP({user, approver, pog}) {


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

## Summary of Changes
Resolves issue #123 

Fixes an issue with the parameters passed to the `.awardApprovalGP()` method of the `ReactionCollectorBase` class. Only the user being awarded the GP (the message author) was being passed to the method, but it also needs the user tag of the approver.

## Testing Procedure
1. Repeat the series of steps that create the error observed in issue 123.
2. Verify that the approver is now listed at the end of the comment, instead of the message author.

## Additional Notes
I know this repository isn't looking for contributors, but, I came across this issue while browsing, and was able to track it down fairly quickly, so thought I'd suggest a fix. Hopefully it's helpful!